### PR TITLE
Fix typo in connect.md

### DIFF
--- a/docs/btn/connect.md
+++ b/docs/btn/connect.md
@@ -24,7 +24,7 @@ Sparkle 是 PBH-BTN 的官方 BTN 服务器。
 
 ## 在 PBH 上加入 BTN 网络
 
-打开 `data/config/confih.yml` 配置文件，找到下面的配置部分：
+打开 `data/config/config.yml` 配置文件，找到下面的配置部分：
 
 ```yaml
 # BitTorrent Threat Network 威胁防护网络（测试版）


### PR DESCRIPTION
confih.yml -> config.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
	- 修正了PBH-BTN服务器文档中的一个拼写错误，确保用户能够找到正确的配置文件路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->