### PR TITLE
docs(Docker.md) It is OK to use the latest tag when using official docker registry.

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/setup/Docker.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/setup/Docker.md
@@ -12,7 +12,7 @@ First visit the [PBH latest version release page](https://github.com/PBH-BTN/Pee
 
 ![image-tag](./assets/docker-tag.png)
 
-**DO NOT** use the latest tag, as it may be cached.
+Please **DO NOT** use the `latest` tag if you choose to use `registry.cn-hangzhou.aliyuncs.com` as Docker registry, else you may get a stale version because it has been cached.
 
 ## Using Docker Compose
 
@@ -25,6 +25,7 @@ services:
     image: "<tags>"
     restart: unless-stopped
     container_name: "peerbanhelper"
+    pull_policy: always
     volumes:
       - ./:/app/data
     ports:
@@ -48,6 +49,6 @@ The webui will be opened at `9898`.
 
 Create a directory as the data storage location for PBH, and switch the working directory to this location.
 ```shell
-sudo docker run -d --name peerbanhelper --stop-timeout -p 9898:9898 -v ${PWD}/:/app/data/ <tags>
+sudo docker run -d --pull always --name peerbanhelper --stop-timeout -p 9898:9898 -v ${PWD}/:/app/data/ <tags>
 ```
 The webui will be opened at `9898`.


### PR DESCRIPTION
Up to date with Chinese version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
	- 修改了 Docker.md 文件，以提高使用 Docker 部署 PeerBanHelper 的说明清晰度和功能性。
	- 扩展了关于使用 `latest` 标签的警告，建议用户在使用 `registry.cn-hangzhou.aliyuncs.com` 时避免使用该标签，以防获取过时版本。
	- 在 Docker Compose 部分新增了 `pull_policy` 设置为 `always`，确保每次启动容器时都拉取最新镜像。
	- 更新了 Docker CLI 部分的运行命令，包含 `--pull always` 选项，以强化始终拉取最新镜像的实践。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->