### PR TITLE
修正错误的 Docker CLI 命令

### DIFF
--- a/docs/setup/Docker.md
+++ b/docs/setup/Docker.md
@@ -42,16 +42,15 @@ services:
 选择一个合适的位置，创建一个目录用于存放 PBH 的数据，并将工作目录切换至此位置。然后，执行以下命令：
 
 ```shell
--sudo docker run -d --name peerbanhelper --stop-timeout -p 9898:9898 -v ${PWD}/:/app/data/ 你的镜像标签
-+sudo docker run -d \
-+    --name peerbanhelper \
-+    --restart unless-stopped \
-+    -p 9898:9898 \
-+    -v ${PWD}/:/app/data/ \
-+    -e PUID=0 \
-+    -e PGID=0 \
-+    -e TZ=UTC \
-+    你的镜像标签
+docker run -d \
+    --name peerbanhelper \
+    --restart unless-stopped \
+    -p 9898:9898 \
+    -v ${PWD}/:/app/data/ \
+    -e PUID=0 \
+    -e PGID=0 \
+    -e TZ=UTC \
+    你的镜像标签
 ```
 :::warning
 在 `-v` 参数中，`$(pwd)/` 表示当前工作目录，应替换为你希望用作数据目录的路径。同时，将 `你的镜像标签` 替换为你刚刚获取的 Docker 镜像标签。

--- a/docs/setup/Docker.md
+++ b/docs/setup/Docker.md
@@ -43,8 +43,9 @@ services:
 
 ```shell
 docker run -d \
-    --name peerbanhelper \
+    --name PeerBanHelper \
     --restart unless-stopped \
+    --stop-timeout 30 \
     -p 9898:9898 \
     -v ${PWD}/:/app/data/ \
     -e PUID=0 \


### PR DESCRIPTION
修正了错误的 Docker CLI 部署命令
（这地方好像是我之前改的从 AI 里复制过来的代码直接粘进去了，没删旧的和前面的 + 号）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
	- 改进了 Docker 部署说明的清晰度和结构。
	- 重新格式化了 Docker CLI 部署部分，增强可读性。
	- 以更结构化的格式保留了关于 `-v` 参数的警告说明。
	- 进行了文本格式和结构的微调，以确保文档的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->